### PR TITLE
[Fixed]: Mode button no longer covered

### DIFF
--- a/src/components/BentoLayout.js
+++ b/src/components/BentoLayout.js
@@ -86,7 +86,7 @@ const BentoLayout = ({ isDarkMode, toggleDarkMode }) => {
       {/* Dark/Light Mode Toggle Button */}
       <button
         onClick={toggleDarkMode}
-        className="p-3 px-4 bg-gray-800 text-white rounded-md fixed top-4 right-4"
+        className="p-3 px-4 bg-gray-800 text-white rounded-md fixed top-4 right-4 z-50"
       >
         {isDarkMode ? (
           <i className="fas fa-sun"></i> // Light Mode icon (Sun icon)


### PR DESCRIPTION
### What does this PR do?

As we noticed on small screen devices, the mode button is coverd by the other components. This PR resolve this issue by added higher z-index value on the mode button.

Fixed #48 

### Screenshots
![Screenshot 2024-10-09 144851](https://github.com/user-attachments/assets/ca1856e1-dae7-44ac-8350-189ce24c4d95)

### Additional context

I ensured that everything works perfectly as before.